### PR TITLE
Support template as promise

### DIFF
--- a/src/single-spa-html.js
+++ b/src/single-spa-html.js
@@ -37,7 +37,9 @@ function bootstrap(opts, props) {
 }
 
 function mount(opts, props) {
-  return Promise.resolve().then(() => {
+  return Promise.resolve(
+    typeof opts.template === "function" ? opts.template(props) : opts.template
+  ).then((template) => {
     const domElementGetter = chooseDomElementGetter(opts, props);
     const domEl = domElementGetter(props);
     if (!domEl) {
@@ -45,10 +47,7 @@ function mount(opts, props) {
         `single-spa-html: domElementGetter did not return a valid dom element`
       );
     }
-    domEl.innerHTML =
-      typeof opts.template === "function"
-        ? opts.template(props)
-        : opts.template;
+    domEl.innerHTML = template;
   });
 }
 

--- a/src/single-spa-html.test.js
+++ b/src/single-spa-html.test.js
@@ -125,4 +125,23 @@ describe("single-spa-html", () => {
         );
       });
   });
+
+  it(`renders function template as promise`, () => {
+    const lifecycles = singleSpaHtml({
+      template: (props) =>
+        Promise.resolve(`<some-web-component></some-web-component>`),
+      domElementGetter,
+    });
+
+    const domEl = domElementGetter();
+
+    return lifecycles
+      .bootstrap(props)
+      .then(() => lifecycles.mount(props))
+      .then(() => {
+        expect(domEl.innerHTML.trim()).toBe(
+          `<some-web-component></some-web-component>`
+        );
+      });
+  });
 });


### PR DESCRIPTION
Other single-spa plugins support promises. Making this one consistent. Lifecycle methods already nicely support promises.

```javascript
singleSpaHtml({
    template: () => fetch(...).then(x => x.text()),
})
```

Tested this on single-spa core using...

```javascript
export const mount = [async (props) => {
     const elm = props.domElementGetter && props.domElementGetter(props);

     if(elm) {
         elm.innerHTML = await fetch(...).then(x => x.text());
    }
}]  

```